### PR TITLE
feat: gitflow, CI/CD workflows, and developer Makefile

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,55 @@
+name: Backport
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+
+jobs:
+  backport:
+    name: Backport ${{ inputs.version }} to develop
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: master
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create backport branch
+        id: branch
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          DATE=$(date +%Y-%m-%d)
+          BACKPORT_BRANCH="backport/${DATE}-${VERSION}"
+          git checkout -b "$BACKPORT_BRANCH"
+          git push origin "$BACKPORT_BRANCH"
+          echo "branch=$BACKPORT_BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Open PR to develop
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.branch.outputs.branch }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          gh pr create \
+            --head "$BRANCH" \
+            --base develop \
+            --title "chore: backport ${VERSION} to develop" \
+            --body "Automated backport of release ${VERSION} to \`develop\`.
+
+          This PR was created automatically after the stable release was published.
+          Merge it to keep \`develop\` in sync with \`master\`." \
+            --label "backport" \
+            --label "automated"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,127 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - master
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  skip-drafts:
+    name: Skip draft PRs
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Not a draft
+        run: echo "PR is ready for review — proceeding with CI"
+
+  validate-branch:
+    name: Validate branch model
+    needs: skip-drafts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch naming convention
+        env:
+          BRANCH: ${{ github.head_ref }}
+        run: |
+          echo "Branch: $BRANCH"
+          if ! echo "$BRANCH" | grep -qE '^(feature|fix|enhancement|refactor|hotfix|beta|backport|dependabot)/'; then
+            echo "ERROR: Branch '$BRANCH' does not match naming conventions."
+            echo "Expected prefix: feature/, fix/, enhancement/, refactor/, hotfix/, beta/, backport/, dependabot/"
+            exit 1
+          fi
+          echo "Branch name is valid."
+
+  analyze:
+    name: Flutter Analyze
+    needs: [skip-drafts, validate-branch]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Activate melos
+        run: dart pub global activate melos
+
+      - name: Bootstrap packages
+        run: melos bootstrap
+
+      - name: Run flutter analyze
+        run: melos exec -- flutter analyze
+
+  test:
+    name: Tests
+    needs: [skip-drafts, validate-branch]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Activate melos
+        run: dart pub global activate melos
+
+      - name: Bootstrap packages
+        run: melos bootstrap
+
+      - name: Run tests
+        run: melos run test
+
+  build-web:
+    name: Build Web (sanity check)
+    needs: [analyze, test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Activate melos
+        run: dart pub global activate melos
+
+      - name: Bootstrap packages
+        run: melos bootstrap
+
+      - name: Build web
+        run: flutter build web --release
+
+  build-android:
+    name: Build Android (sanity check)
+    needs: [analyze, test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Activate melos
+        run: dart pub global activate melos
+
+      - name: Bootstrap packages
+        run: melos bootstrap
+
+      - name: Build APK
+        run: flutter build apk --release

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,152 @@
+name: Pre-release
+
+on:
+  push:
+    branches:
+      - 'beta/**'
+      - 'hotfix/**'
+
+concurrency:
+  group: prerelease-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-web:
+    name: Build Web
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Activate melos
+        run: dart pub global activate melos
+
+      - name: Bootstrap packages
+        run: melos bootstrap
+
+      - name: Build web
+        run: flutter build web --release
+
+      - name: Zip web build
+        run: zip -r smart-warehouse-web.zip build/web
+
+      - name: Upload web artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-build
+          path: smart-warehouse-web.zip
+
+  build-android:
+    name: Build Android
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Activate melos
+        run: dart pub global activate melos
+
+      - name: Bootstrap packages
+        run: melos bootstrap
+
+      - name: Build APK
+        run: flutter build apk --release
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-build
+          path: build/app/outputs/flutter-apk/app-release.apk
+
+  release:
+    name: Publish pre-release
+    needs: [build-web, build-android]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Derive pre-release tag
+        id: tag
+        run: |
+          BRANCH="${GITHUB_REF#refs/heads/}"
+          echo "Branch: $BRANCH"
+          if [[ "$BRANCH" == beta/* ]]; then
+            SERIES="${BRANCH#beta/}"
+            EXISTING=$(git tag -l "beta-${SERIES}-*" | sort -V | tail -1)
+            if [ -z "$EXISTING" ]; then
+              N=1
+            else
+              LAST_N="${EXISTING##*-}"
+              N=$((LAST_N + 1))
+            fi
+            TAG="beta-${SERIES}-${N}"
+          elif [[ "$BRANCH" == hotfix/* ]]; then
+            VERSION="${BRANCH#hotfix/}"
+            EXISTING=$(git tag -l "hotfix-${VERSION}-*" | sort -V | tail -1)
+            if [ -z "$EXISTING" ]; then
+              N=1
+            else
+              LAST_N="${EXISTING##*-}"
+              N=$((LAST_N + 1))
+            fi
+            TAG="hotfix-${VERSION}-${N}"
+          else
+            echo "ERROR: unexpected branch '$BRANCH'" >&2
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Pre-release tag: $TAG"
+
+      - name: Download web artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: web-build
+          path: .
+
+      - name: Download android artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: android-build
+          path: .
+
+      - name: Create git tag
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$TAG"
+          git push origin "$TAG"
+
+      - name: Create GitHub pre-release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          name: Pre-release ${{ steps.tag.outputs.tag }}
+          prerelease: true
+          files: |
+            smart-warehouse-web.zip
+            app-release.apk
+          generate_release_notes: true

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -1,0 +1,152 @@
+name: Stable Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - master
+
+jobs:
+  gate:
+    name: Verify release conditions
+    if: >
+      github.event.pull_request.merged == true &&
+      (startsWith(github.event.pull_request.head.ref, 'beta/') ||
+       startsWith(github.event.pull_request.head.ref, 'hotfix/'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Release conditions verified
+        run: echo "Merged from release branch — proceeding with stable release"
+
+  build-web:
+    name: Build Web
+    needs: gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Activate melos
+        run: dart pub global activate melos
+
+      - name: Bootstrap packages
+        run: melos bootstrap
+
+      - name: Build web
+        run: flutter build web --release
+
+      - name: Zip web build
+        run: zip -r smart-warehouse-web.zip build/web
+
+      - name: Upload web artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-build
+          path: smart-warehouse-web.zip
+
+  build-android:
+    name: Build Android
+    needs: gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Activate melos
+        run: dart pub global activate melos
+
+      - name: Bootstrap packages
+        run: melos bootstrap
+
+      - name: Build APK
+        run: flutter build apk --release
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-build
+          path: build/app/outputs/flutter-apk/app-release.apk
+
+  stable-release:
+    name: Publish stable release
+    needs: [build-web, build-android]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    outputs:
+      version: ${{ steps.tag.outputs.version }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Derive stable version tag
+        id: tag
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          BRANCH="$HEAD_REF"
+          if [[ "$BRANCH" == beta/* ]]; then
+            VERSION="${BRANCH#beta/}"
+          elif [[ "$BRANCH" == hotfix/* ]]; then
+            VERSION="${BRANCH#hotfix/}"
+          else
+            echo "ERROR: unexpected branch '$BRANCH'" >&2
+            exit 1
+          fi
+          echo "version=v${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Stable version: v${VERSION}"
+
+      - name: Download web artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: web-build
+          path: .
+
+      - name: Download android artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: android-build
+          path: .
+
+      - name: Create git tag
+        env:
+          VERSION: ${{ steps.tag.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$VERSION"
+          git push origin "$VERSION"
+
+      - name: Create stable release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.version }}
+          name: Release ${{ steps.tag.outputs.version }}
+          prerelease: false
+          files: |
+            smart-warehouse-web.zip
+            app-release.apk
+          generate_release_notes: true
+
+  trigger-backport:
+    name: Trigger backport to develop
+    needs: stable-release
+    uses: ./.github/workflows/backport.yml
+    with:
+      version: ${{ needs.stable-release.outputs.version }}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+.PHONY: setup generate analyze test clean dev pr-checks help
+
+.DEFAULT_GOAL := help
+
+setup: ## Install dependencies across all packages
+	dart pub global activate melos
+	melos bootstrap
+
+generate: ## Run code generation across all packages that use build_runner
+	melos run generate
+
+analyze: ## Run static analysis across all packages
+	melos exec -- flutter analyze
+
+test: ## Run tests across all packages
+	melos run test
+
+clean: ## Clean build artifacts across all packages
+	melos exec -- flutter clean
+
+dev: ## Start the Flutter web dev server with hot reload
+	flutter run -d chrome
+
+pr-checks: analyze test ## Run the same checks CI would run on a PR
+
+help: ## Show available commands
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'

--- a/melos.yaml
+++ b/melos.yaml
@@ -17,3 +17,8 @@ scripts:
     exec: dart run build_runner build --delete-conflicting-outputs
     packageFilters:
       dependsOn: build_runner
+  test:
+    exec: |
+      if [ -d "test" ]; then
+        flutter test --no-pub
+      fi


### PR DESCRIPTION
## Summary

- Add four GitHub Actions workflows mirroring the backend's gitflow (`ci`, `prerelease`, `stable-release`, `backport`)
- Add `Makefile` with developer commands (`setup`, `generate`, `analyze`, `test`, `clean`, `dev`, `pr-checks`)
- Adopt the same branching model as `wh-backend`: `develop`/`master`, with `beta/**` and `hotfix/**` release branches

## Workflows

| Workflow | Trigger | What it does |
|---|---|---|
| `ci.yml` | PR to `develop` or `master` | Validates branch name, runs `flutter analyze` + tests, sanity builds Web + Android in parallel |
| `prerelease.yml` | Push to `beta/**` / `hotfix/**` | Builds Web + Android in parallel, publishes GitHub pre-release with both artifacts |
| `stable-release.yml` | Merge to `master` from `beta/**` / `hotfix/**` | Builds, tags `vX.Y.Z`, publishes stable GitHub Release, triggers backport |
| `backport.yml` | Called by stable-release | Opens `backport/YYYY-MM-DD-vX.Y.Z` PR back to `develop` |

## Security hardening applied

- Branch name validated before running expensive jobs (fail-fast)
- All `${{ github.* }}` and `${{ steps.*.outputs.* }}` expressions passed via `env:` blocks, never interpolated directly into shell scripts
- `$GITHUB_OUTPUT` quoted throughout

## Makefile

```
make setup       # melos bootstrap
make generate    # build_runner on all packages
make analyze     # flutter analyze across all packages
make test        # run tests (skips packages with no test/ dir)
make clean       # flutter clean across all packages
make dev         # flutter run -d chrome
make pr-checks   # analyze + test (mirrors CI locally)
make help        # list all commands
```

## Test plan

- [ ] Open a PR from a `feature/*` branch → CI workflow triggers, branch name validates, analyze and tests run
- [ ] Open a PR from a branch with a bad prefix → `validate-branch` fails fast, no Flutter jobs run
- [ ] Push to `beta/1.0.0` → pre-release workflow triggers, both artifacts appear on GitHub Releases
- [ ] Merge `beta/1.0.0` to `master` → stable release published as `v1.0.0`, backport PR opened to `develop`
- [ ] Run `make pr-checks` locally → analyze and tests pass