### PR TITLE
fix(order_tracking): correct WS path and fetch full page from /orders

### DIFF
--- a/packages/features/order_tracking/lib/src/data/repositories/remote_order_tracking_repository.dart
+++ b/packages/features/order_tracking/lib/src/data/repositories/remote_order_tracking_repository.dart
@@ -28,10 +28,33 @@ class RemoteOrderTrackingRepository implements OrderTrackingRepository {
   /// watchOrder replaces the scheme to ws:// internally.
   final String baseUrl;
 
+  /// Decodifica el `sub` (userId) del payload del JWT. El back registra los
+  /// handlers WS bajo `/ws/v1/orders/{userId}` con un interceptor que matchea
+  /// el `userId` del JWT contra el del path — necesitamos el id, no solo el
+  /// token, para construir la URL.
+  static String? _userIdFromToken(String token) {
+    try {
+      final parts = token.split('.');
+      if (parts.length != 3) return null;
+      var payload = parts[1].replaceAll('-', '+').replaceAll('_', '/');
+      payload = payload.padRight((payload.length + 3) ~/ 4 * 4, '=');
+      final decoded = utf8.decode(base64.decode(payload));
+      final json = jsonDecode(decoded) as Map<String, dynamic>;
+      return json['sub'] as String?;
+    } catch (_) {
+      return null;
+    }
+  }
+
   @override
   Future<Either<OrderTrackingFailure, List<Order>>> getOrders() async {
     try {
-      final result = await httpHelper.get('/orders');
+      // El back devuelve paginado con default size=10; pedimos el máximo (50)
+      // para cubrir el caso común sin implementar UI de paginación todavía.
+      final result = await httpHelper.get(
+        '/orders',
+        queryParameters: const {'page': 0, 'size': 50},
+      );
       return result.fold(
         (error) => Left(OrderTrackingFailure(_mapError(error))),
         (response) {
@@ -106,10 +129,18 @@ class RemoteOrderTrackingRepository implements OrderTrackingRepository {
           }
           return;
         }
+        final userId = _userIdFromToken(token);
+        if (userId == null) {
+          if (!controller.isClosed) {
+            controller.addError(Exception('Token inválido'));
+          }
+          return;
+        }
 
         final wsUrl = baseUrl.replaceFirst(RegExp(r'^http'), 'ws');
-        final channel =
-            WebSocketChannel.connect(Uri.parse('$wsUrl/ws?token=$token'));
+        final channel = WebSocketChannel.connect(
+          Uri.parse('$wsUrl/ws/v1/orders/$userId?token=$token'),
+        );
         attempt = 0;
 
         await for (final message in channel.stream) {
@@ -172,10 +203,16 @@ class RemoteOrderTrackingRepository implements OrderTrackingRepository {
           await Future<void>.delayed(const Duration(seconds: 5));
           continue;
         }
+        final userId = _userIdFromToken(token);
+        if (userId == null) {
+          await Future<void>.delayed(const Duration(seconds: 5));
+          continue;
+        }
 
         final wsUrl = baseUrl.replaceFirst(RegExp(r'^http'), 'ws');
-        final channel =
-            WebSocketChannel.connect(Uri.parse('$wsUrl/ws?token=$token'));
+        final channel = WebSocketChannel.connect(
+          Uri.parse('$wsUrl/ws/v1/orders/$userId?token=$token'),
+        );
         attempt = 0;
 
         await for (final message in channel.stream) {


### PR DESCRIPTION
## WS path equivocado

El back en `WebSocketConfig` registra:

- `/ws/v1/orders` (solo admins)
- `/ws/v1/orders/{userId}` (user-scoped, interceptor matchea `sub` del JWT contra el `{userId}` del path)
- `/ws/v1/vehicles`, `/ws/v1/stock/alerts`

El front estaba conectando a **`/ws?token=...`** (path inexistente). El handshake devolvía 403 silencioso y el reconnect loop nunca conseguía un socket vivo — ni `OrderDetailCubit.watch` ni el `OrderNotificationCubit` recibían eventos.

**Fix:** decodifico el `sub` del JWT inline (base64url del payload) y armo la URL `/ws/v1/orders/{userId}?token=...`. Sin agregar dependencias.

## Pagination del GET /orders

El back devuelve `{ "orders": [...], "pagination": { ... } }` con default `size=10`. El front parseaba solo `orders`, ignoraba `pagination`, y se perdía cualquier orden después de la décima. Subo a `size=50` (el máximo del back) — cubre el caso común sin implementar UI de paginación todavía.

## Conocido / no abordado en este PR

- `watchOrderStatusChanges` abre un segundo socket en paralelo a `watchOrder`. Es duplicación pero no es un bug crítico — refactor para otro PR.
- POST /orders sigue requiriendo `ADMIN_SALES`/`ADMIN_WAREHOUSE`; si los usuarios mobile son operadores comunes, no van a poder crear órdenes — ese es un tema de permisos del back, no del front.

## Test plan

- [x] \`dart analyze\` limpio
- [ ] Smoke contra back vivo: login → tab Órdenes → ver lista → detail → status update via API → notificación in-app