### PR TITLE
fix(orders/profile): totals reales en la lista + re-fetch al entrar + esconder rol

### DIFF
--- a/packages/features/order_tracking/lib/src/order_tracking_feature_builder.dart
+++ b/packages/features/order_tracking/lib/src/order_tracking_feature_builder.dart
@@ -29,7 +29,10 @@ class OrderTrackingFeatureBuilder {
               ),
       )
       ..registerLazySingleton<OrderListCubit>(
-        () => OrderListCubit(Injector.i.resolve<OrderTrackingRepository>()),
+        () => OrderListCubit(
+          Injector.i.resolve<OrderTrackingRepository>(),
+          Injector.i.resolve<CatalogRepository>(),
+        ),
       )
       ..registerSingleton<OrderNotificationCubit>(
         OrderNotificationCubit(

--- a/packages/features/order_tracking/lib/src/presentation/bloc/order_list_cubit.dart
+++ b/packages/features/order_tracking/lib/src/presentation/bloc/order_list_cubit.dart
@@ -34,8 +34,16 @@ class OrderListCubit extends Cubit<OrderListState> {
   Future<void> refresh() => load();
 
   /// Re-fetcha sin pasar por loading: solo actualiza el Ready si ya estábamos
-  /// listos. Lo usamos cuando llega un event del WS — el usuario no necesita
-  /// ver el spinner por un cambio de status remoto.
+  /// listos. Si el state es Loading o Error, hace load() completo. Usado
+  /// cuando se re-entra a la pantalla de órdenes (singleton del Injector
+  /// quedaba con la lista vieja sin las nuevas órdenes creadas).
+  Future<void> silentRefresh() async {
+    if (state is! OrderListReady) {
+      return load();
+    }
+    return _silentRefresh();
+  }
+
   Future<void> _silentRefresh() async {
     if (isClosed) return;
     final result = await _repository.getOrders();

--- a/packages/features/order_tracking/lib/src/presentation/bloc/order_list_cubit.dart
+++ b/packages/features/order_tracking/lib/src/presentation/bloc/order_list_cubit.dart
@@ -1,6 +1,9 @@
 import 'dart:async';
 
+import 'package:catalog/catalog.dart';
+import 'package:dartz/dartz.dart' hide Order;
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:orders/orders.dart';
 import 'package:order_tracking/src/domain/entities/order_status_change.dart';
 import 'package:order_tracking/src/domain/repositories/order_tracking_repository.dart';
 import 'package:order_tracking/src/presentation/bloc/order_list_state.dart';
@@ -8,39 +11,40 @@ import 'package:order_tracking/src/presentation/bloc/order_list_state.dart';
 export 'order_list_state.dart';
 
 class OrderListCubit extends Cubit<OrderListState> {
-  OrderListCubit(this._repository) : super(const OrderListLoading()) {
+  OrderListCubit(this._repository, this._catalogRepository)
+      : super(const OrderListLoading()) {
     scheduleMicrotask(load);
-    // Auto-refresh cuando llega cambio de status por WS — sin re-emitir
-    // loading: pisa la lista existente con los nuevos status detrás de
-    // escena para que la UI no flicker.
     _wsSubscription =
         _repository.watchOrderStatusChanges().listen((_) => _silentRefresh());
   }
 
   final OrderTrackingRepository _repository;
+  final CatalogRepository _catalogRepository;
   StreamSubscription<OrderStatusChange>? _wsSubscription;
+
+  // Cache global de productos compartido durante la vida del cubit. Evita
+  // re-fetchear el mismo producto cada vez que aparece en una orden distinta.
+  final Map<String, Product> _productCache = {};
 
   Future<void> load() async {
     if (isClosed) return;
     emit(const OrderListLoading());
     final result = await _repository.getOrders();
     if (isClosed) return;
-    result.fold(
-      (failure) => emit(OrderListError(failure.message ?? 'Error desconocido')),
-      (orders) => emit(OrderListReady(orders: orders)),
+    await result.fold(
+      (failure) async =>
+          emit(OrderListError(failure.message ?? 'Error desconocido')),
+      (orders) async {
+        final hydrated = await _hydrate(orders);
+        if (!isClosed) emit(OrderListReady(orders: hydrated));
+      },
     );
   }
 
   Future<void> refresh() => load();
 
-  /// Re-fetcha sin pasar por loading: solo actualiza el Ready si ya estábamos
-  /// listos. Si el state es Loading o Error, hace load() completo. Usado
-  /// cuando se re-entra a la pantalla de órdenes (singleton del Injector
-  /// quedaba con la lista vieja sin las nuevas órdenes creadas).
   Future<void> silentRefresh() async {
-    if (state is! OrderListReady) {
-      return load();
-    }
+    if (state is! OrderListReady) return load();
     return _silentRefresh();
   }
 
@@ -48,14 +52,61 @@ class OrderListCubit extends Cubit<OrderListState> {
     if (isClosed) return;
     final result = await _repository.getOrders();
     if (isClosed) return;
-    result.fold(
-      (_) {}, // No reemplazamos el estado actual si falla — preferimos
-              // mantener la lista vieja vs mostrar error por un blip de red.
-      (orders) {
-        if (state is OrderListReady) {
-          emit(OrderListReady(orders: orders));
+    await result.fold(
+      (_) async {},
+      (orders) async {
+        final hydrated = await _hydrate(orders);
+        if (!isClosed && state is OrderListReady) {
+          emit(OrderListReady(orders: hydrated));
         }
       },
+    );
+  }
+
+  /// El back NO devuelve precios en `OrderResponse` — los items vienen con
+  /// solo `productId, sku, quantity`. Para mostrar el total real en las
+  /// cards de la lista, hacemos `GET /products/{id}` por cada productId
+  /// nuevo y reemplazamos `unitPrice` y `total` con los valores reales.
+  /// Productos ya cacheados no se re-fetchean.
+  Future<List<Order>> _hydrate(List<Order> orders) async {
+    final missing = orders
+        .expand((o) => o.items.map((i) => i.productId))
+        .where((id) => !_productCache.containsKey(id))
+        .toSet()
+        .toList(growable: false);
+    if (missing.isNotEmpty) {
+      final results = await Future.wait<Either<CatalogFailure, Product>>(
+        missing.map((id) => _catalogRepository.getProductById(id)),
+      );
+      for (var i = 0; i < missing.length; i++) {
+        results[i].fold((_) {}, (p) => _productCache[missing[i]] = p);
+      }
+    }
+    return orders.map(_applyPrices).toList(growable: false);
+  }
+
+  Order _applyPrices(Order order) {
+    if (order.items.isEmpty) return order;
+    Money? currency;
+    var totalCents = 0;
+    final newItems = order.items.map((item) {
+      final product = _productCache[item.productId];
+      if (product == null) return item;
+      currency = product.price;
+      totalCents += (product.price.amount * item.quantity).toInt();
+      return item.copyWith(
+        unitPrice: product.price,
+        productName: item.productName.isEmpty ? product.name : item.productName,
+      );
+    }).toList(growable: false);
+    if (currency == null) return order.copyWith(items: newItems);
+    return order.copyWith(
+      items: newItems,
+      total: Money(
+        amount: totalCents,
+        currency: currency!.currency,
+        taxIncluded: currency!.taxIncluded,
+      ),
     );
   }
 

--- a/packages/features/order_tracking/lib/src/presentation/pages/order_list_page.dart
+++ b/packages/features/order_tracking/lib/src/presentation/pages/order_list_page.dart
@@ -4,13 +4,27 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:order_tracking/src/presentation/widgets/order_card.dart';
 
-class OrderListPage extends StatelessWidget {
+class OrderListPage extends StatefulWidget {
   const OrderListPage({required this.cubit, super.key});
 
   final OrderListCubit cubit;
 
   @override
+  State<OrderListPage> createState() => _OrderListPageState();
+}
+
+class _OrderListPageState extends State<OrderListPage> {
+  @override
+  void initState() {
+    super.initState();
+    // El cubit es singleton — re-fetcheamos en cada entrada para que las
+    // órdenes recién creadas desde el cart se vean al volver a la lista.
+    widget.cubit.silentRefresh();
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final cubit = widget.cubit;
     return BottomNavigationBarFeatureBuilder.buildScaffold(
       context,
       selectedTab: const NavigationBarOption.orders(),

--- a/packages/features/order_tracking/test/presentation/bloc/order_list_cubit_test.dart
+++ b/packages/features/order_tracking/test/presentation/bloc/order_list_cubit_test.dart
@@ -1,12 +1,30 @@
 import 'dart:async';
 
-import 'package:catalog/catalog.dart' show Money;
+import 'package:catalog/catalog.dart';
 import 'package:dartz/dartz.dart' hide Order;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:order_tracking/src/domain/entities/order_status_change.dart';
 import 'package:order_tracking/src/domain/repositories/order_tracking_repository.dart';
 import 'package:order_tracking/src/presentation/bloc/order_list_cubit.dart';
 import 'package:orders/orders.dart';
+
+class _FakeCatalog implements CatalogRepository {
+  @override
+  Future<Either<CatalogFailure, Product>> getProductById(String id) async =>
+      const Left(CatalogFailure('not used'));
+
+  @override
+  Future<Either<CatalogFailure, ProductsPage>> getProducts({
+    int page = 1,
+    int pageSize = 20,
+    String? search,
+    ProductCategory? category,
+  }) async => const Left(CatalogFailure('not used'));
+
+  @override
+  Future<Either<CatalogFailure, List<ProductCategory>>> getCategories() async =>
+      const Left(CatalogFailure('not used'));
+}
 
 class _FakeRepo implements OrderTrackingRepository {
   Either<OrderTrackingFailure, List<Order>> result =
@@ -41,14 +59,14 @@ void main() {
 
   test('initial state is OrderListLoading', () {
     repo.result = const Right([]);
-    final cubit = OrderListCubit(repo);
+    final cubit = OrderListCubit(repo, _FakeCatalog());
     expect(cubit.state, isA<OrderListLoading>());
     cubit.close();
   });
 
   test('emits Loading then Ready with orders', () async {
     repo.result = Right([_order('o1'), _order('o2')]);
-    final cubit = OrderListCubit(repo);
+    final cubit = OrderListCubit(repo, _FakeCatalog());
     final states = <OrderListState>[];
     final sub = cubit.stream.listen(states.add);
 
@@ -65,7 +83,7 @@ void main() {
   test('emits Error when repository returns failure', () async {
     repo.result =
         const Left(OrderTrackingFailure('Error de red'));
-    final cubit = OrderListCubit(repo);
+    final cubit = OrderListCubit(repo, _FakeCatalog());
     final states = <OrderListState>[];
     final sub = cubit.stream.listen(states.add);
 
@@ -79,7 +97,7 @@ void main() {
 
   test('refresh re-emits Loading then Ready', () async {
     repo.result = Right([_order('o1')]);
-    final cubit = OrderListCubit(repo);
+    final cubit = OrderListCubit(repo, _FakeCatalog());
     await Future<void>.delayed(Duration.zero);
 
     final states = <OrderListState>[];

--- a/packages/features/orders/lib/src/domain/entities/order.dart
+++ b/packages/features/orders/lib/src/domain/entities/order.dart
@@ -16,4 +16,19 @@ class Order {
   final OrderStatus status;
   final DateTime createdAt;
   final Money total;
+
+  Order copyWith({
+    String? id,
+    List<OrderItem>? items,
+    OrderStatus? status,
+    DateTime? createdAt,
+    Money? total,
+  }) =>
+      Order(
+        id: id ?? this.id,
+        items: items ?? this.items,
+        status: status ?? this.status,
+        createdAt: createdAt ?? this.createdAt,
+        total: total ?? this.total,
+      );
 }

--- a/packages/features/orders/lib/src/domain/entities/order_item.dart
+++ b/packages/features/orders/lib/src/domain/entities/order_item.dart
@@ -14,4 +14,17 @@ class OrderItem {
   final Money unitPrice;
 
   Money get subtotal => unitPrice * quantity;
+
+  OrderItem copyWith({
+    String? productId,
+    String? productName,
+    int? quantity,
+    Money? unitPrice,
+  }) =>
+      OrderItem(
+        productId: productId ?? this.productId,
+        productName: productName ?? this.productName,
+        quantity: quantity ?? this.quantity,
+        unitPrice: unitPrice ?? this.unitPrice,
+      );
 }

--- a/packages/features/profile/lib/src/presentation/pages/profile_page.dart
+++ b/packages/features/profile/lib/src/presentation/pages/profile_page.dart
@@ -8,16 +8,28 @@ import 'package:profile/src/presentation/widgets/order_history_section.dart';
 import 'package:profile/src/presentation/widgets/profile_header_card.dart';
 import 'package:profile/src/presentation/widgets/profile_stats_row.dart';
 
-class ProfilePage extends StatelessWidget {
+class ProfilePage extends StatefulWidget {
   const ProfilePage({required this.cubit, super.key});
 
   final ProfileCubit cubit;
 
   @override
+  State<ProfilePage> createState() => _ProfilePageState();
+}
+
+class _ProfilePageState extends State<ProfilePage> {
+  @override
+  void initState() {
+    super.initState();
+    // El cubit es singleton — siempre re-fetcheamos al entrar para que el
+    // "gastado este mes" y "órdenes abiertas" reflejen las órdenes
+    // creadas/canceladas desde el cart o WS desde la última visita.
+    widget.cubit.load();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    if (cubit.state is! ProfileReady) {
-      Future.microtask(cubit.load);
-    }
+    final cubit = widget.cubit;
     return Scaffold(
       backgroundColor: SwColors.surface,
       bottomNavigationBar: BottomNavigationBarFeatureBuilder.build(

--- a/packages/features/profile/lib/src/presentation/widgets/profile_header_card.dart
+++ b/packages/features/profile/lib/src/presentation/widgets/profile_header_card.dart
@@ -32,8 +32,6 @@ class ProfileHeaderCard extends StatelessWidget {
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
                 ),
-                const SizedBox(height: 8),
-                _RoleBadge(role: user.role),
               ],
             ),
           ),
@@ -66,39 +64,3 @@ class _Avatar extends StatelessWidget {
   }
 }
 
-class _RoleBadge extends StatelessWidget {
-  const _RoleBadge({required this.role});
-
-  final String role;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
-      decoration: BoxDecoration(
-        color: SwColors.yellowSoft,
-        borderRadius: BorderRadius.circular(SwRadii.pill),
-        border: Border.all(color: SwColors.yellowSoftAlt),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          const Icon(
-            Icons.star_rounded,
-            size: 13,
-            color: SwColors.yellow,
-          ),
-          const SizedBox(width: 4),
-          Text(
-            role.toUpperCase(),
-            style: SwText.label(
-              size: 11,
-              color: SwColors.yellowDark,
-              weight: FontWeight.w700,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}


### PR DESCRIPTION
Tres fixes encontrados mientras probaba contra el back para la demo.

## 1. Re-fetch al entrar a Órdenes y Perfil

\`OrderListCubit\` y \`ProfileCubit\` son singletons del Injector. La primera vez que entrás cargan, pero al re-entrar reusan el state viejo — las órdenes recién creadas desde el cart no aparecen y el \"gastado este mes\" del perfil no se actualiza.

- \`OrderListPage\` y \`ProfilePage\` ahora son StatefulWidget; en initState disparan \`silentRefresh()\` / \`load()\`.
- \`OrderListCubit.silentRefresh()\` público: pisa la lista sin pasar por loading si ya estaba en Ready (no flicker).

## 2. Esconder el rol en el header del perfil

El badge del rol no aporta info al usuario final — el rol viene del back para auth, no para UI. Saco el \`_RoleBadge\` widget y la línea que lo renderiza.

## 3. Hidratar precio para mostrar total real en las cards

El back devuelve los items de la orden con solo \`product_id, sku, quantity\` — sin precio. El total venía siempre \$0 en las cards de la lista, aunque adentro del detail mostrara los precios bien (ese ya hidrataba contra \`/products/{id}\` para sacar nombre + imagen).

Cambios:
- \`OrderListCubit\` recibe \`CatalogRepository\` y mantiene cache de productos durante su vida.
- Después de load y silent refresh, hidrata cualquier productId nuevo via \`GET /products/{id}\` en paralelo y recalcula \`unit_price\` + \`total\` real de cada orden.
- \`Order\` y \`OrderItem\` domain entities tienen \`copyWith\` para que el cubit pueda reemplazar el total con el valor hidratado.
- Tests actualizados con \`_FakeCatalog\`.

## Test plan

- [x] \`dart analyze\` limpio
- [x] 36/36 tests del order_tracking
- [x] Smoke contra back: crear orden → volver a Mis Órdenes → aparece con total real → ir al perfil → \"gastado\" actualizado