### PR TITLE
fix(profile/cart): cargar perfil antes de abrir el checkout sheet

### DIFF
--- a/packages/features/profile/lib/src/profile_feature_builder.dart
+++ b/packages/features/profile/lib/src/profile_feature_builder.dart
@@ -45,6 +45,14 @@ class ProfileFeatureBuilder {
     BuildContext context,
   ) async {
     final cubit = Injector.i.resolve<ProfileCubit>();
+    // El cubit es singleton — si el usuario nunca abrió el tab de Perfil,
+    // sigue en Loading y `state.user.address` no existe. Forzamos load()
+    // antes de leer el address, así el form se autocompleta con lo
+    // guardado en el back.
+    if (cubit.state is! ProfileReady) {
+      await cubit.load();
+    }
+    if (!context.mounted) return null;
     final state = cubit.state;
     final initial = state is ProfileReady ? state.user.address : null;
     final result = await showModalBottomSheet<CheckoutAddressResult>(


### PR DESCRIPTION
Si el usuario va directo al cart sin pasar antes por el tab de Perfil, el form de dirección abre vacío aunque tenga una dirección guardada en el back.

**Causa**: ProfileCubit es singleton del Injector. Solo se carga cuando se entra a ProfilePage. Si nunca se abrió Perfil, sigue en Loading → collectCheckoutAddress leía state inexistente → initial=null.

**Fix**: si el cubit no está Ready, await cubit.load() antes de leer el address. Chequeo context.mounted post-await.